### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,5 +121,5 @@ python main.py
 
 <!--
 ## 统计
-![Star History Chart](https://api.star-history.com/svg?repos=linzjian666/chromego_extractor&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=linzjian666/chromego_extractor&type=Date)
 -->

--- a/README_EN.md
+++ b/README_EN.md
@@ -116,5 +116,5 @@ This project is licensed under the MIT License. For detailed information, please
 
 <!--
 ## Statistics
-![Star History Chart](https://api.star-history.com/svg?repos=linzjian666/chromego_extractor&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=linzjian666/chromego_extractor&type=Date)
 -->


### PR DESCRIPTION
This project is excellent and very useful, but the star history chart in the README has been broken and no longer renders. This change fixes it by switching to a working alternative provider so the chart is visible again.